### PR TITLE
aws-sesバージョンアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+vendor/*
+*.swp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-ses (0.6.0)
+    aws-ses (0.7.1)
       builder
       mail (> 2.2.5)
       mime-types
@@ -162,12 +162,12 @@ GEM
     method_source (0.9.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2021.0225)
     mimemagic (0.3.10)
       nokogiri (~> 1)
       rake
     mini_magick (4.9.5)
-    mini_mime (1.0.2)
+    mini_mime (1.1.0)
     mini_portile2 (2.4.0)
     minitest (5.13.0)
     msgpack (1.3.1)
@@ -321,7 +321,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    xml-simple (1.1.5)
+    xml-simple (1.1.8)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.2.2)

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -3,5 +3,6 @@ ActionMailer::Base.add_delivery_method(
   AWS::SES::Base,
   access_key_id: Rails.application.credentials.dig(:aws, :access_key_id),
   secret_access_key: Rails.application.credentials.dig(:aws, :secret_access_key),
-  server: 'email.us-east-1.amazonaws.com'
+  server: 'email.us-east-1.amazonaws.com',
+  signature_version: 4,
 )


### PR DESCRIPTION
## 概要(Overview)
aws-sesの署名バージョン3が廃止されてしまい、警告が発生している。
署名バージョン4に上げるために、aws-sesのバージョンを上げる。

## 技術的変更点・見所(Technical change)
- aws-sesを0.7.0以上にバージョンアップ

## マイグレーション(Migration)
なし

## 関連URL(Related URL)
https://github.com/drewblas/aws-ses