### PR TITLE
aws-sesバージョンアップ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "image_processing", "~> 1.2"
 
 # AWS
 gem "aws-sdk-s3", require: false
-gem "aws-ses"
+gem "aws-ses", git: "https://github.com/zebitex/aws-ses.git", ref: "78-sigv4-problem"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/zebitex/aws-ses.git
+  revision: 65e1ff1c3c2031b243f773cb9e61df6e49db71dd
+  ref: 78-sigv4-problem
+  specs:
+    aws-ses (0.7.1)
+      builder
+      mail (> 2.2.5)
+      mime-types
+      xml-simple
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -75,11 +86,6 @@ GEM
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-ses (0.7.1)
-      builder
-      mail (> 2.2.5)
-      mime-types
-      xml-simple
     aws-sigv4 (1.1.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
@@ -332,7 +338,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import
   aws-sdk-s3
-  aws-ses
+  aws-ses!
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)


### PR DESCRIPTION
## 概要(Overview)
aws-sesの署名バージョン3が廃止されてしまい、警告が発生している。
署名バージョン4に上げるために、aws-sesのバージョンを上げる。

## 技術的変更点・見所(Technical change)
- aws-sesを0.7.0以上にバージョンアップ

## マイグレーション(Migration)
なし

## 関連URL(Related URL)
https://github.com/drewblas/aws-ses
https://github.com/drewblas/aws-ses/issues/78#issuecomment-759586655