### PR TITLE
サイト改修_202205-02

### DIFF
--- a/app/controllers/learn_records_controller.rb
+++ b/app/controllers/learn_records_controller.rb
@@ -68,6 +68,8 @@ class LearnRecordsController < ApplicationController
     end
 
     def correct_user?
+      return false unless user_signed_in?
+
       @learn_record = LearnRecord.find(params[:id])
       view_context.is_same_user?(current_user.id, @learn_record.user_id) || is_admin_user?
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -50,7 +50,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
     devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:family_name, :first_name, :family_name_kana, :first_name_kana, :nickname, :pref_id, :users_category_id, :users_job_category_id, :gender, :birthdate, :studying, :introduction, :avatar])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:family_name, :first_name, :family_name_kana, :first_name_kana, :nickname, :pref_id, :users_category_id, :users_job_category_id, :gender, :birthdate, :studying, :introduction, :twitter, :instagram, :avatar])
   end
 
   def create_birthdate_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @upcoming_events = Event.upcoming_events(@user.id)
     @past_events = Event.past_events(@user.id)
+    myself_user?
   end
 
   def events
@@ -24,5 +25,14 @@ class UsersController < ApplicationController
                 .limit(40)
                 .page(params[:page])
                 .per(10)
+  end
+
+
+  private
+  def myself_user?
+    user = User.find(params[:id])
+    @myself_user = user_signed_in? ? 
+      view_context.is_same_user?(current_user.id, user.id) :
+      false
   end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -646,3 +646,9 @@ div.field_with_errors {
     }
   }
 }
+
+.sns-link {
+  &:hover {
+    text-decoration: none;
+  }  
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,11 @@ class User < ApplicationRecord
   has_one_attached :avatar
   validate :avatar_presence, on: :update, unless: :encrypted_password_changed?
 
+  TWITTER_REGEXP = /\A\w{1,15}\z|\A\z/
+  INSTAGRAM_REGEXP = /\A(?!\.)[\w.]{1,30}(?<!\.)\z|\A\z/
+  validates :twitter, format: { with: TWITTER_REGEXP }, on: :update, unless: :encrypted_password_changed?
+  validates :instagram, format: { with: INSTAGRAM_REGEXP }, on: :update, unless: :encrypted_password_changed?
+
   has_many :events
   has_many :events_users
   has_many :learn_records

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -123,6 +123,24 @@
         <%= f.text_area :introduction, autofocus: true, class: 'form-control', rows: 8 %>
       </div>
 
+      <div class="field mb-4">
+        <%= f.label :twitter do %>
+          <i class="fab fa-twitter" aria-hidden="true"></i>
+          Twitterアカウント
+        <% end %><br />
+        https://twitter.com/
+        <%= f.text_field :twitter, autofocus: true, class: 'form-control', style: 'width: 35%; display: inline-block;' %>
+      </div>
+
+      <div class="field mb-4">
+        <%= f.label :instagram do %>
+          <i class="fab fa-instagram" aria-hidden="true"></i>
+          Instagramアカウント
+        <% end %><br />
+        https://instagram.com/
+        <%= f.text_field :instagram, autofocus: true, class: 'form-control', style: 'width: 35%; display: inline-block;'  %>
+      </div>
+
       <div class="actions">
         <%= f.submit "更新する", class: 'sign-up-btn btn-block mt-3' %>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,7 +24,9 @@
         </div>
       </div>
       <p style="word-wrap: break-word;"><%= @user.introduction.present? ? hbr(@user.introduction).html_safe : 'プロフィール文未設定' %></p>
-      <a class="sign-up-btn text-center" style="width: 100%;display: block" href="/users/edit">プロフィールを編集する</a>
+      <% if @myself_user %>
+        <a class="sign-up-btn text-center" style="width: 100%;display: block" href="/users/edit">プロフィールを編集する</a>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,8 +5,24 @@
         <%= image_tag(@user.avatar.variant(resize: "100x100"), class: 'rounded') if @user.avatar.attached? %>
         <a class="text-decoration-none p-2 border border-danger h-25 rounded-pill" href="/menu" style="color: #DC564F;">メニュー</a>
       </div>
-      <p class="mt-4 mb-0 font-weight-bold">氏名: <%= @user.display_priority_nickname %></p>
-      <p class="font-weight-bold" style="color:gray;">学習している事: <%= @user.studying %></p>
+      <div class="d-flex justify-content-between mt-4">
+        <div>
+          <p class="mb-0 font-weight-bold">氏名: <%= @user.display_priority_nickname %></p>
+          <p class="font-weight-bold" style="color:gray;">学習している事: <%= @user.studying %></p>
+        </div>
+        <div class="sns-area" style="max-height: 100%;">
+          <% unless @user.twitter.blank? %>
+            <%= link_to "https://twitter.com/#{@user.twitter}", target: :_blank, rel: "noopener noreferrer", class: "sns-link" do %>
+              <i class="fab fa-twitter fa-2x"></i>
+            <% end %>
+          <% end %>
+          <% unless @user.instagram.blank? %>
+            <%= link_to "https://instagram.com/#{@user.instagram}", target: :_blank, rel: "noopener noreferrer", class: "sns-link" do %>
+              <i class="fab fa-instagram fa-2x"></i>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
       <p style="word-wrap: break-word;"><%= @user.introduction.present? ? hbr(@user.introduction).html_safe : 'プロフィール文未設定' %></p>
       <a class="sign-up-btn text-center" style="width: 100%;display: block" href="/users/edit">プロフィールを編集する</a>
     </div>

--- a/db/migrate/20220521114337_add_sns_accounts_to_users.rb
+++ b/db/migrate/20220521114337_add_sns_accounts_to_users.rb
@@ -1,0 +1,6 @@
+class AddSnsAccountsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :twitter, :string, after: :birthdate, comment: 'Twitterアカウント'
+    add_column :users, :instagram, :string, after: :twitter, comment: 'Instagramアカウント'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_020813) do
+ActiveRecord::Schema.define(version: 2022_05_21_114337) do
 
   create_table "action_text_rich_texts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
@@ -152,6 +152,8 @@ ActiveRecord::Schema.define(version: 2020_04_21_020813) do
     t.string "studying", comment: "勉強している事"
     t.text "introduction", comment: "自己紹介"
     t.date "birthdate", comment: "誕生日"
+    t.string "twitter", comment: "Twitterアカウント"
+    t.string "instagram", comment: "Instagramアカウント"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe "twitter, instagramのバリデーションチェック" do
+    let(:user) { FactoryBot.create(:user) }
+    subject { user.valid? }
+
+    context "twitter" do
+      it "nilは有効" do
+        user.twitter = nil
+        is_expected.to eq true
+      end
+
+      it "空文字は有効" do
+        user.twitter = ''
+        is_expected.to eq true
+      end
+
+      it "15文字以内の[a-zA-Z_0-9]は有効" do
+        valid_twitters = [
+          "abc_DEF_123",      # 全パターンの文字列を含む
+          "a",                # 最小長：1文字
+          "123456789012345",  # 最大長：15文字
+        ]
+
+        aggregate_failures do
+          valid_twitters.each do |valid_twitter|
+            user.twitter = valid_twitter
+            expect(user.valid?).to eq true 
+          end
+        end
+      end
+
+      it "15文字以内の[a-zA-Z_0-9]に該当しない場合は無効" do
+        valid_twitters = [
+          "abc_DEF_123#",     # 不正な文字を含む（記号）
+          "abc_DEF_123あ",    # 不正な文字を含む（全角文字列）
+          "1234567890123456", # 最大長：15文字を超える
+        ]
+
+        aggregate_failures do
+          valid_twitters.each do |valid_twitter|
+            user.twitter = valid_twitter
+            expect(user.valid?).to eq false
+          end
+        end
+      end
+    end
+
+    context "instagram" do
+      it "nilは有効" do
+        user.instagram = nil
+        is_expected.to eq true
+      end
+
+      it "空文字は有効" do
+        user.instagram = ''
+        is_expected.to eq true
+      end
+
+      it "30文字以内の[a-zA-Z_.0-9]（先頭末尾に.を用いない）は有効" do
+        valid_instagrams = [
+          "abc_DEF.123",      # 全パターンの文字列を含む
+          "a",                # 最小長：1文字
+          "123456789012345678901234567890",  # 最大長：30文字
+        ]
+
+        aggregate_failures do
+          valid_instagrams.each do |valid_instagram|
+            user.instagram = valid_instagram
+            expect(user.valid?).to eq true 
+          end
+        end
+      end
+
+      it "30文字以内の[a-zA-Z_.0-9]（先頭末尾に.を用いない）に該当しない場合は無効" do
+        valid_instagrams = [
+          "abc_DEF.123#",     # 不正な文字を含む（記号）
+          "abc_DEF.123あ",    # 不正な文字を含む（全角文字列）
+          ".abc_DEF.123",     # 先頭に.を用いる
+          "abc_DEF.123.",     # 末尾に.を用いる
+          "1234567890123456789012345678901", # 最大長：30文字を超える
+        ]
+
+        aggregate_failures do
+          valid_instagrams.each do |valid_instagram|
+            user.instagram = valid_instagram
+            expect(user.valid?).to eq false
+          end
+        end
+      end
+    end
+  
+  end
+end

--- a/spec/requests/users/users_information_spec.rb
+++ b/spec/requests/users/users_information_spec.rb
@@ -29,6 +29,39 @@ RSpec.describe "ユーザーアカウント管理", type: :request do
             params: { user: params_hash }
         }.not_to change { new_registration_confirmed_user }
       end
+
+      it "twitter, instagramの情報を入れて更新できる" do
+        birthdate_attribute = { "birthdate(1i)" => "1989", "birthdate(2i)" => "12", "birthdate(3i)" => "10" }
+        sns_attribute = { "twitter" => "aaa", "instagram" => "bbb" }
+        params_hash.merge!(birthdate_attribute).merge!(sns_attribute)
+        patch user_registration_path,
+          params: { user: params_hash }
+        new_registration_confirmed_user.reload
+        aggregate_failures do
+          expect(new_registration_confirmed_user.twitter).to eq("aaa")
+          expect(new_registration_confirmed_user.instagram).to eq("bbb")
+        end
+      end
+
+      it "twitterが不正な値の場合、更新できない" do
+        birthdate_attribute = { "birthdate(1i)" => "1989", "birthdate(2i)" => "12", "birthdate(3i)" => "10" }
+        twitter_attribute = { "twitter" => "あああ" }
+        params_hash.merge!(birthdate_attribute).merge!(twitter_attribute)
+        expect {
+          patch user_registration_path,
+            params: { user: params_hash }
+        }.not_to change { new_registration_confirmed_user }
+      end
+      
+      it "instagramが不正な値の場合、更新できない" do
+        birthdate_attribute = { "birthdate(1i)" => "1989", "birthdate(2i)" => "12", "birthdate(3i)" => "10" }
+        twitter_attribute = { "instagram" => "いいい" }
+        params_hash.merge!(birthdate_attribute).merge!(twitter_attribute)
+        expect {
+          patch user_registration_path,
+            params: { user: params_hash }
+        }.not_to change { new_registration_confirmed_user }
+      end
     end
   end
 end

--- a/spec/system/learn_records_spec.rb
+++ b/spec/system/learn_records_spec.rb
@@ -41,57 +41,66 @@ RSpec.describe "learn_records", type: :system do
       end
     end
 
-    context "自分で作ったブログ" do
+    context "ログイン前" do
       before do
-        visit new_user_session_path
-        fill_in "メールアドレス", with: user.email
-        fill_in "パスワード", with: user.password
-        click_button "ログイン"
-
         visit learn_record_path(user_learn_record)
       end
-
-      it_behaves_like 'show edit and delete links and they work correctly'
-
-    end
-
-    context "他人が作ったブログ（一般ユーザー）" do
-      before do
-        visit new_user_session_path
-        fill_in "メールアドレス", with: other_user.email
-        fill_in "パスワード", with: other_user.password
-        click_button "ログイン"
-
-        visit learn_record_path(user_learn_record)
-      end
-
       it_behaves_like "don't show edit and delete links"
     end
 
-    context "他人が作ったブログ（マネージャー）" do
-      before do
-        visit new_user_session_path
-        fill_in "メールアドレス", with: manager_user.email
-        fill_in "パスワード", with: manager_user.password
-        click_button "ログイン"
-
-        visit learn_record_path(user_learn_record)
+    context "ログイン後" do
+      context "自分で作ったブログ" do
+        before do
+          visit new_user_session_path
+          fill_in "メールアドレス", with: user.email
+          fill_in "パスワード", with: user.password
+          click_button "ログイン"
+  
+          visit learn_record_path(user_learn_record)
+        end
+  
+        it_behaves_like 'show edit and delete links and they work correctly'
+  
       end
-
-      it_behaves_like "don't show edit and delete links"
-    end
-
-    context "他人が作ったブログ（管理ユーザー）" do
-      before do
-        visit new_user_session_path
-        fill_in "メールアドレス", with: admin_user.email
-        fill_in "パスワード", with: admin_user.password
-        click_button "ログイン"
-
-        visit learn_record_path(user_learn_record)
+  
+      context "他人が作ったブログ（一般ユーザー）" do
+        before do
+          visit new_user_session_path
+          fill_in "メールアドレス", with: other_user.email
+          fill_in "パスワード", with: other_user.password
+          click_button "ログイン"
+  
+          visit learn_record_path(user_learn_record)
+        end
+  
+        it_behaves_like "don't show edit and delete links"
       end
-
-      it_behaves_like 'show edit and delete links and they work correctly'
+  
+      context "他人が作ったブログ（マネージャー）" do
+        before do
+          visit new_user_session_path
+          fill_in "メールアドレス", with: manager_user.email
+          fill_in "パスワード", with: manager_user.password
+          click_button "ログイン"
+  
+          visit learn_record_path(user_learn_record)
+        end
+  
+        it_behaves_like "don't show edit and delete links"
+      end
+  
+      context "他人が作ったブログ（管理ユーザー）" do
+        before do
+          visit new_user_session_path
+          fill_in "メールアドレス", with: admin_user.email
+          fill_in "パスワード", with: admin_user.password
+          click_button "ログイン"
+  
+          visit learn_record_path(user_learn_record)
+        end
+  
+        it_behaves_like 'show edit and delete links and they work correctly'
+      end
     end
   end
 

--- a/spec/system/user_show_spec.rb
+++ b/spec/system/user_show_spec.rb
@@ -4,72 +4,109 @@ require "rails_helper"
 
 RSpec.describe "ユーザー詳細ページ", type: :system do
   let!(:user) { FactoryBot.create(:user) }
+  let!(:other_user) { FactoryBot.create(:user) }
 
-  before do
+  def login_action
     visit new_user_session_path
-    fill_in "メールアドレス", with: login_user.email
-    fill_in "パスワード", with: login_user.password
+    fill_in "メールアドレス", with: user.email
+    fill_in "パスワード", with: user.password
     click_button "ログイン"
   end
 
   context "snsアカウント" do
-    let(:login_user) { user }
-    it "twitter/instagramがnilの場合、snsアイコンは非表示" do
-      user.update(twitter: nil, instagram: nil)
-      visit user_path(user)
-      
-      aggregate_failures do
-        expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
-        expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+
+    RSpec.shared_examples 'show sns icons' do
+      it "instagram,twitterが設定されている場合、twitter, instagramアイコンは表示" do
+        user.update(twitter: 'aaaa', instagram: 'bbbb')
+        visit user_path(user)
+  
+        aggregate_failures do
+          twitter_link = page.find('div.sns-area').find_link(href: 'https://twitter.com/aaaa')
+          expect(twitter_link).to have_selector("svg.fa-twitter")
+          instagram_link = page.find('div.sns-area').find_link(href: 'https://instagram.com/bbbb')
+          expect(instagram_link).to have_selector("svg.fa-instagram")
+        end
       end
-      # expect(page).to have_selector("img[src$='/jisyuu-top1.png']")
-      # expect(page.find_link(href: 'https://www.tokyoselfstudy.com/blogs/620', visible: false)).to have_selector("img[src$='/jisyuu-top2.png?20210918']", visible: false)
-      # expect(page.find_link(href: 'https://www.tokyoselfstudy.com/blogs/20', visible: false)).to have_selector("img[src$='/jisyuu-top3.png']", visible: false)
-      # expect(page.find_link(href: 'https://www.tokyoselfstudy.com/blogs/248', visible: false)).to have_selector("img[src$='/jisyuu-top4.png']", visible: false)
     end
 
-     it "twitter/instagramがブランクの場合、snsアイコンは非表示" do
-      user.update(twitter: '', instagram: '')
-      visit user_path(user)
+    context "ログイン前も表示される" do
+      it_behaves_like 'show sns icons'
+    end
 
-      aggregate_failures do
-        expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
-        expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+    context "ログイン後" do
+      before do
+        login_action
       end
-     end
-
-     it "twitterが設定されている場合、twitterアイコンは表示（instagramは非表示）" do
-      user.update(twitter: 'aaaa', instagram: '')
-      visit user_path(user)
-
-      aggregate_failures do
-        twitter_link = page.find('div.sns-area').find_link(href: 'https://twitter.com/aaaa')
-        expect(twitter_link).to have_selector("svg.fa-twitter")
-        expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+  
+      it "twitter/instagramがnilの場合、snsアイコンは非表示" do
+        user.update(twitter: nil, instagram: nil)
+        visit user_path(user)
+        
+        aggregate_failures do
+          expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
+          expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+        end
       end
-     end
-
-     it "instagramが設定されている場合、instagramアイコンは表示（twitterは非表示）" do
-      user.update(twitter: '', instagram: 'bbbb')
-      visit user_path(user)
-
-      aggregate_failures do
-        instagram_link = page.find('div.sns-area').find_link(href: 'https://instagram.com/bbbb')
-        expect(instagram_link).to have_selector("svg.fa-instagram")
-        expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
+  
+      it "twitter/instagramがブランクの場合、snsアイコンは非表示" do
+        user.update(twitter: '', instagram: '')
+        visit user_path(user)
+  
+        aggregate_failures do
+          expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
+          expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+        end
       end
-     end
-
-     it "instagram,twitterが設定されている場合、twitter, instagramアイコンは表示" do
-      user.update(twitter: 'aaaa', instagram: 'bbbb')
-      visit user_path(user)
-
-      aggregate_failures do
-        twitter_link = page.find('div.sns-area').find_link(href: 'https://twitter.com/aaaa')
-        expect(twitter_link).to have_selector("svg.fa-twitter")
-        instagram_link = page.find('div.sns-area').find_link(href: 'https://instagram.com/bbbb')
-        expect(instagram_link).to have_selector("svg.fa-instagram")
+  
+      it "twitterが設定されている場合、twitterアイコンは表示（instagramは非表示）" do
+        user.update(twitter: 'aaaa', instagram: '')
+        visit user_path(user)
+  
+        aggregate_failures do
+          twitter_link = page.find('div.sns-area').find_link(href: 'https://twitter.com/aaaa')
+          expect(twitter_link).to have_selector("svg.fa-twitter")
+          expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+        end
       end
-     end
+  
+      it "instagramが設定されている場合、instagramアイコンは表示（twitterは非表示）" do
+        user.update(twitter: '', instagram: 'bbbb')
+        visit user_path(user)
+  
+        aggregate_failures do
+          instagram_link = page.find('div.sns-area').find_link(href: 'https://instagram.com/bbbb')
+          expect(instagram_link).to have_selector("svg.fa-instagram")
+          expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
+        end
+      end
+  
+      it_behaves_like 'show sns icons'
+
+    end
+  end
+
+  context "プロフィールを編集するボタン" do
+    context "ログイン前" do
+      it "ボタンは非表示" do
+        visit user_path(user)
+        expect(page.find('div.profile-block')).not_to have_link href: '/users/edit'
+      end
+    end
+
+    context "ログイン後" do
+      before do
+        login_action
+      end
+
+      it "自分のプロフィール上には表示" do
+        visit user_path(user)
+        expect(page.find('div.profile-block')).to have_link href: '/users/edit'
+      end
+
+      it "他人のプロフィール上には非表示" do
+        visit user_path(other_user)
+        expect(page.find('div.profile-block')).not_to have_link href: '/users/edit'
+      end
+    end
   end
 end

--- a/spec/system/user_show_spec.rb
+++ b/spec/system/user_show_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ユーザー詳細ページ", type: :system do
+  let!(:user) { FactoryBot.create(:user) }
+
+  before do
+    visit new_user_session_path
+    fill_in "メールアドレス", with: login_user.email
+    fill_in "パスワード", with: login_user.password
+    click_button "ログイン"
+  end
+
+  context "snsアカウント" do
+    let(:login_user) { user }
+    it "twitter/instagramがnilの場合、snsアイコンは非表示" do
+      user.update(twitter: nil, instagram: nil)
+      visit user_path(user)
+      
+      aggregate_failures do
+        expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
+        expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+      end
+      # expect(page).to have_selector("img[src$='/jisyuu-top1.png']")
+      # expect(page.find_link(href: 'https://www.tokyoselfstudy.com/blogs/620', visible: false)).to have_selector("img[src$='/jisyuu-top2.png?20210918']", visible: false)
+      # expect(page.find_link(href: 'https://www.tokyoselfstudy.com/blogs/20', visible: false)).to have_selector("img[src$='/jisyuu-top3.png']", visible: false)
+      # expect(page.find_link(href: 'https://www.tokyoselfstudy.com/blogs/248', visible: false)).to have_selector("img[src$='/jisyuu-top4.png']", visible: false)
+    end
+
+     it "twitter/instagramがブランクの場合、snsアイコンは非表示" do
+      user.update(twitter: '', instagram: '')
+      visit user_path(user)
+
+      aggregate_failures do
+        expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
+        expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+      end
+     end
+
+     it "twitterが設定されている場合、twitterアイコンは表示（instagramは非表示）" do
+      user.update(twitter: 'aaaa', instagram: '')
+      visit user_path(user)
+
+      aggregate_failures do
+        twitter_link = page.find('div.sns-area').find_link(href: 'https://twitter.com/aaaa')
+        expect(twitter_link).to have_selector("svg.fa-twitter")
+        expect(page.find('div.sns-area')).not_to have_link href: 'https://instagram.com/'
+      end
+     end
+
+     it "instagramが設定されている場合、instagramアイコンは表示（twitterは非表示）" do
+      user.update(twitter: '', instagram: 'bbbb')
+      visit user_path(user)
+
+      aggregate_failures do
+        instagram_link = page.find('div.sns-area').find_link(href: 'https://instagram.com/bbbb')
+        expect(instagram_link).to have_selector("svg.fa-instagram")
+        expect(page.find('div.sns-area')).not_to have_link href: 'https://twitter.com/'
+      end
+     end
+
+     it "instagram,twitterが設定されている場合、twitter, instagramアイコンは表示" do
+      user.update(twitter: 'aaaa', instagram: 'bbbb')
+      visit user_path(user)
+
+      aggregate_failures do
+        twitter_link = page.find('div.sns-area').find_link(href: 'https://twitter.com/aaaa')
+        expect(twitter_link).to have_selector("svg.fa-twitter")
+        instagram_link = page.find('div.sns-area').find_link(href: 'https://instagram.com/bbbb')
+        expect(instagram_link).to have_selector("svg.fa-instagram")
+      end
+     end
+  end
+end


### PR DESCRIPTION
- S029
  - マイページの修正
    - マイページに「ツイッター」「インスタ」のリンクを貼れる様にする。

- S032
  - （石橋発案）マイページの修正
    - 自分のマイページの場合のみ、「プロフィールを編集する」を表示する。

- S024（バグ修正）
  - ログイン前に正しくみんなのブログが表示されない不具合を修正

- 参考資料
https://drive.google.com/file/d/1KyM0yDdkAVMJLV8MCF2P5OVDCZuLcbsJ/view